### PR TITLE
FixedPoint improvements

### DIFF
--- a/contracts/libraries/AddressStringUtil.sol
+++ b/contracts/libraries/AddressStringUtil.sol
@@ -4,7 +4,7 @@ pragma solidity >=0.5.0;
 
 library AddressStringUtil {
     // converts an address to the uppercase hex string, extracting only len bytes (up to 20, multiple of 2)
-    function toAsciiString(address addr, uint len) pure internal returns (string memory) {
+    function toAsciiString(address addr, uint len) internal pure returns (string memory) {
         require(len % 2 == 0 && len > 0 && len <= 40, "AddressStringUtil: INVALID_LEN");
 
         bytes memory s = new bytes(len);
@@ -25,7 +25,7 @@ library AddressStringUtil {
     // hi and lo are only 4 bits and between 0 and 16
     // this method converts those values to the unicode/ascii code point for the hex representation
     // uses upper case for the characters
-    function char(uint8 b) pure private returns (byte c) {
+    function char(uint8 b) private pure returns (byte c) {
         if (b < 10) {
             return byte(b + 0x30);
         } else {

--- a/contracts/libraries/FixedPoint.sol
+++ b/contracts/libraries/FixedPoint.sol
@@ -19,8 +19,8 @@ library FixedPoint {
     }
 
     uint8 private constant RESOLUTION = 112;
-    uint120 private constant Q112 = uint120(1) << RESOLUTION;
-    uint232 private constant Q224 = uint232(Q112) << RESOLUTION;
+    uint private constant Q112 = uint(1) << RESOLUTION;
+    uint private constant Q224 = Q112 << RESOLUTION;
 
     // encode a uint112 as a UQ112x112
     function encode(uint112 x) internal pure returns (uq112x112 memory) {
@@ -68,8 +68,7 @@ library FixedPoint {
     // reverts on overflow
     // lossy
     function reciprocal(uq112x112 memory self) internal pure returns (uq112x112 memory) {
-        require(self._x != 0, 'FixedPoint: DIV_BY_ZERO_RECIPROCAL');
-        require(self._x != 1, 'FixedPoint: RECIPROCAL_OVERFLOW');
+        require(self._x > 1, 'FixedPoint: DIV_BY_ZERO_RECIPROCAL_OR_OVERFLOW');
         return uq112x112(uint224(Q224 / self._x));
     }
 

--- a/contracts/libraries/FixedPoint.sol
+++ b/contracts/libraries/FixedPoint.sol
@@ -77,7 +77,7 @@ library FixedPoint {
         return uq112x112(uint224(Q224 / self._x));
     }
 
-    // square root of a UQ112x112
+    // square root of a UQ112x112, lossy to 40 bits
     function sqrt(uq112x112 memory self) internal pure returns (uq112x112 memory) {
         return uq112x112(uint224(Babylonian.sqrt(uint(self._x) << 32) << 40));
     }

--- a/contracts/libraries/FixedPoint.sol
+++ b/contracts/libraries/FixedPoint.sol
@@ -58,9 +58,9 @@ library FixedPoint {
     }
 
     // divide a UQ112x112 by a uint112, returning a UQ112x112
-    function div(uq112x112 memory self, uint112 x) internal pure returns (uq112x112 memory) {
-        require(x != 0, 'FixedPoint: DIV_BY_ZERO');
-        return uq112x112(self._x / x);
+    function div(uq112x112 memory self, uint112 y) internal pure returns (uq112x112 memory) {
+        require(y != 0, 'FixedPoint: DIV_BY_ZERO');
+        return uq112x112(self._x / y);
     }
 
     // returns a UQ112x112 which represents the ratio of the numerator to the denominator

--- a/contracts/libraries/FixedPoint.sol
+++ b/contracts/libraries/FixedPoint.sol
@@ -50,18 +50,19 @@ library FixedPoint {
         return uq144x112(z);
     }
 
-    // multiply a UQ112x112 by an int and decode, returning an int
-    // reverts on overflow
-    function muli(uq112x112 memory self, int y) internal pure returns (int) {
-        uint144 z = decode144(mul(self, uint(y < 0 ? -y : y)));
-        return y < 0 ? -z : z;
-    }
-
     // divide a UQ112x112 by a uint112, returning a UQ112x112
     function div(uq112x112 memory self, uint112 y) internal pure returns (uq112x112 memory) {
         require(y != 0, 'FixedPoint: DIV_BY_ZERO');
         return uq112x112(self._x / y);
     }
+
+    // multiply a UQ112x112 by an int and decode, returning an int
+    // reverts on overflow
+    function muli(uq112x112 memory self, int y) internal pure returns (int) {
+        uint144 z = decode144(mul(self, uint(y < 0 ? -y : y)));
+        return y < 0 ? -int(z) : z;
+    }
+
 
     // returns a UQ112x112 which represents the ratio of the numerator to the denominator
     // equivalent to encode(numerator).div(denominator)

--- a/contracts/libraries/FixedPoint.sol
+++ b/contracts/libraries/FixedPoint.sol
@@ -50,12 +50,6 @@ library FixedPoint {
         return uq144x112(z);
     }
 
-    // divide a UQ112x112 by a uint112, returning a UQ112x112
-    function div(uq112x112 memory self, uint112 y) internal pure returns (uq112x112 memory) {
-        require(y != 0, 'FixedPoint: DIV_BY_ZERO');
-        return uq112x112(self._x / y);
-    }
-
     // multiply a UQ112x112 by an int and decode, returning an int
     // reverts on overflow
     function muli(uq112x112 memory self, int y) internal pure returns (int) {
@@ -63,21 +57,24 @@ library FixedPoint {
         return y < 0 ? -int(z) : z;
     }
 
-
     // returns a UQ112x112 which represents the ratio of the numerator to the denominator
-    // equivalent to encode(numerator).div(denominator)
+    // lossy
     function fraction(uint112 numerator, uint112 denominator) internal pure returns (uq112x112 memory) {
         require(denominator > 0, "FixedPoint: DIV_BY_ZERO_FRACTION");
         return uq112x112((uint224(numerator) << RESOLUTION) / denominator);
     }
 
     // take the reciprocal of a UQ112x112
+    // reverts on overflow
+    // lossy
     function reciprocal(uq112x112 memory self) internal pure returns (uq112x112 memory) {
         require(self._x != 0, 'FixedPoint: DIV_BY_ZERO_RECIPROCAL');
+        require(self._x != 1, 'FixedPoint: RECIPROCAL_OVERFLOW');
         return uq112x112(uint224(Q224 / self._x));
     }
 
-    // square root of a UQ112x112, lossy to 40 bits
+    // square root of a UQ112x112
+    // lossy to 40 bits
     function sqrt(uq112x112 memory self) internal pure returns (uq112x112 memory) {
         return uq112x112(uint224(Babylonian.sqrt(uint(self._x) << 32) << 40));
     }

--- a/contracts/libraries/FixedPoint.sol
+++ b/contracts/libraries/FixedPoint.sol
@@ -19,8 +19,8 @@ library FixedPoint {
     }
 
     uint8 private constant RESOLUTION = 112;
-    uint private constant Q112 = uint(1) << RESOLUTION;
-    uint private constant Q224 = Q112 << RESOLUTION;
+    uint120 private constant Q112 = uint120(1) << RESOLUTION;
+    uint232 private constant Q224 = uint232(Q112) << RESOLUTION;
 
     // encode a uint112 as a UQ112x112
     function encode(uint112 x) internal pure returns (uq112x112 memory) {
@@ -30,27 +30,6 @@ library FixedPoint {
     // encodes a uint144 as a UQ144x112
     function encode144(uint144 x) internal pure returns (uq144x112 memory) {
         return uq144x112(uint(x) << RESOLUTION);
-    }
-
-    // divide a UQ112x112 by a uint112, returning a UQ112x112
-    function div(uq112x112 memory self, uint112 x) internal pure returns (uq112x112 memory) {
-        require(x != 0, 'FixedPoint: DIV_BY_ZERO');
-        return uq112x112(self._x / x);
-    }
-
-    // multiply a UQ112x112 by a uint, returning a UQ144x112
-    // reverts on overflow
-    function mul(uq112x112 memory self, uint y) internal pure returns (uq144x112 memory) {
-        uint z;
-        require(y == 0 || (z = self._x * y) / y == self._x, "FixedPoint: MULTIPLICATION_OVERFLOW");
-        return uq144x112(z);
-    }
-
-    // returns a UQ112x112 which represents the ratio of the numerator to the denominator
-    // equivalent to encode(numerator).div(denominator)
-    function fraction(uint112 numerator, uint112 denominator) internal pure returns (uq112x112 memory) {
-        require(denominator > 0, "FixedPoint: DIV_BY_ZERO");
-        return uq112x112((uint224(numerator) << RESOLUTION) / denominator);
     }
 
     // decode a UQ112x112 into a uint112 by truncating after the radix point
@@ -63,9 +42,37 @@ library FixedPoint {
         return uint144(self._x >> RESOLUTION);
     }
 
+    // multiply a UQ112x112 by a uint, returning a UQ144x112
+    // reverts on overflow
+    function mul(uq112x112 memory self, uint y) internal pure returns (uq144x112 memory) {
+        uint z;
+        require(y == 0 || (z = self._x * y) / y == self._x, "FixedPoint: MULTIPLICATION_OVERFLOW");
+        return uq144x112(z);
+    }
+
+    // multiply a UQ112x112 by an int and decode, returning an int
+    // reverts on overflow
+    function muli(uq112x112 memory self, int y) internal pure returns (int) {
+        uint144 z = decode144(mul(self, uint(y < 0 ? -y : y)));
+        return y < 0 ? -z : z;
+    }
+
+    // divide a UQ112x112 by a uint112, returning a UQ112x112
+    function div(uq112x112 memory self, uint112 x) internal pure returns (uq112x112 memory) {
+        require(x != 0, 'FixedPoint: DIV_BY_ZERO');
+        return uq112x112(self._x / x);
+    }
+
+    // returns a UQ112x112 which represents the ratio of the numerator to the denominator
+    // equivalent to encode(numerator).div(denominator)
+    function fraction(uint112 numerator, uint112 denominator) internal pure returns (uq112x112 memory) {
+        require(denominator > 0, "FixedPoint: DIV_BY_ZERO_FRACTION");
+        return uq112x112((uint224(numerator) << RESOLUTION) / denominator);
+    }
+
     // take the reciprocal of a UQ112x112
     function reciprocal(uq112x112 memory self) internal pure returns (uq112x112 memory) {
-        require(self._x != 0, 'FixedPoint: ZERO_RECIPROCAL');
+        require(self._x != 0, 'FixedPoint: DIV_BY_ZERO_RECIPROCAL');
         return uq112x112(uint224(Q224 / self._x));
     }
 

--- a/contracts/libraries/FixedPoint.sol
+++ b/contracts/libraries/FixedPoint.sol
@@ -29,20 +29,20 @@ library FixedPoint {
 
     // encodes a uint144 as a UQ144x112
     function encode144(uint144 x) internal pure returns (uq144x112 memory) {
-        return uq144x112(uint256(x) << RESOLUTION);
+        return uq144x112(uint(x) << RESOLUTION);
     }
 
     // divide a UQ112x112 by a uint112, returning a UQ112x112
     function div(uq112x112 memory self, uint112 x) internal pure returns (uq112x112 memory) {
         require(x != 0, 'FixedPoint: DIV_BY_ZERO');
-        return uq112x112(self._x / uint224(x));
+        return uq112x112(self._x / x);
     }
 
     // multiply a UQ112x112 by a uint, returning a UQ144x112
     // reverts on overflow
     function mul(uq112x112 memory self, uint y) internal pure returns (uq144x112 memory) {
         uint z;
-        require(y == 0 || (z = uint(self._x) * y) / y == uint(self._x), "FixedPoint: MULTIPLICATION_OVERFLOW");
+        require(y == 0 || (z = self._x * y) / y == self._x, "FixedPoint: MULTIPLICATION_OVERFLOW");
         return uq144x112(z);
     }
 
@@ -71,6 +71,6 @@ library FixedPoint {
 
     // square root of a UQ112x112
     function sqrt(uq112x112 memory self) internal pure returns (uq112x112 memory) {
-        return uq112x112(uint224(Babylonian.sqrt(uint256(self._x)) << 56));
+        return uq112x112(uint224(Babylonian.sqrt(uint(self._x) << 32) << 40));
     }
 }

--- a/contracts/test/AddressStringUtilTest.sol
+++ b/contracts/test/AddressStringUtilTest.sol
@@ -5,7 +5,7 @@ pragma solidity >=0.5.0;
 import "../libraries/AddressStringUtil.sol";
 
 contract AddressStringUtilTest {
-    function toAsciiString(address addr, uint len) pure external returns (string memory) {
+    function toAsciiString(address addr, uint len) external pure returns (string memory) {
         return AddressStringUtil.toAsciiString(addr, len);
     }
 }

--- a/contracts/test/FixedPointTest.sol
+++ b/contracts/test/FixedPointTest.sol
@@ -14,27 +14,28 @@ contract FixedPointTest {
         return FixedPoint.encode144(x);
     }
 
-    // divide a UQ112x112 by a uint112, returning a UQ112x112
-    function div(FixedPoint.uq112x112 calldata self, uint112 y) external pure returns (FixedPoint.uq112x112 memory) {
-        return FixedPoint.div(self, y);
-    }
-
-    function fraction(uint112 numerator, uint112 denominator) external pure returns (FixedPoint.uq112x112 memory) {
-        return FixedPoint.fraction(numerator, denominator);
-    }
-
-    // multiply a UQ112x112 by a uint, returning a UQ144x112
-    function mul(FixedPoint.uq112x112 calldata self, uint y) external pure returns (FixedPoint.uq144x112 memory) {
-        return FixedPoint.mul(self, y);
-    }
-
-    // decode a UQ112x112 in a uint container into a uint by truncating after the radix point
     function decode(FixedPoint.uq112x112 calldata self) external pure returns (uint112) {
         return FixedPoint.decode(self);
     }
 
     function decode144(FixedPoint.uq144x112 calldata self) external pure returns (uint144) {
         return FixedPoint.decode144(self);
+    }
+
+    function mul(FixedPoint.uq112x112 calldata self, uint y) external pure returns (FixedPoint.uq144x112 memory) {
+        return FixedPoint.mul(self, y);
+    }
+
+    function div(FixedPoint.uq112x112 calldata self, uint112 y) external pure returns (FixedPoint.uq112x112 memory) {
+        return FixedPoint.div(self, y);
+    }
+
+    function muli(FixedPoint.uq112x112 calldata self, int y) external pure returns (int) {
+        return FixedPoint.muli(self, y);
+    }
+
+    function fraction(uint112 numerator, uint112 denominator) external pure returns (FixedPoint.uq112x112 memory) {
+        return FixedPoint.fraction(numerator, denominator);
     }
 
     function reciprocal(FixedPoint.uq112x112 calldata self) external pure returns (FixedPoint.uq112x112 memory) {

--- a/contracts/test/FixedPointTest.sol
+++ b/contracts/test/FixedPointTest.sol
@@ -26,10 +26,6 @@ contract FixedPointTest {
         return FixedPoint.mul(self, y);
     }
 
-    function div(FixedPoint.uq112x112 calldata self, uint112 y) external pure returns (FixedPoint.uq112x112 memory) {
-        return FixedPoint.div(self, y);
-    }
-
     function muli(FixedPoint.uq112x112 calldata self, int y) external pure returns (int) {
         return FixedPoint.muli(self, y);
     }

--- a/contracts/test/SafeERC20NamerTest.sol
+++ b/contracts/test/SafeERC20NamerTest.sol
@@ -16,8 +16,7 @@ contract SafeERC20NamerTest {
 }
 
 // does not implement name or symbol
-contract NamerTestFakeOptionalERC20 {
-}
+contract NamerTestFakeOptionalERC20 {}
 
 // complies with ERC20 and returns strings
 contract NamerTestFakeCompliantERC20 {

--- a/contracts/test/TransferHelperTest.sol
+++ b/contracts/test/TransferHelperTest.sol
@@ -33,17 +33,17 @@ contract TransferHelperTestFakeERC20Compliant {
         shouldRevert = shouldRevert_;
     }
 
-    function transfer(address, uint256) public view returns (bool) {
+    function transfer(address, uint) public view returns (bool) {
         require(!shouldRevert, 'REVERT');
         return success;
     }
 
-    function transferFrom(address, address, uint256) public view returns (bool) {
+    function transferFrom(address, address, uint) public view returns (bool) {
         require(!shouldRevert, 'REVERT');
         return success;
     }
 
-    function approve(address, uint256) public view returns (bool) {
+    function approve(address, uint) public view returns (bool) {
         require(!shouldRevert, 'REVERT');
         return success;
     }
@@ -57,15 +57,15 @@ contract TransferHelperTestFakeERC20Noncompliant {
         shouldRevert = shouldRevert_;
     }
 
-    function transfer(address, uint256) view public {
+    function transfer(address, uint) view public {
         require(!shouldRevert);
     }
 
-    function transferFrom(address, address, uint256) view public {
+    function transferFrom(address, address, uint) view public {
         require(!shouldRevert);
     }
 
-    function approve(address, uint256) view public {
+    function approve(address, uint) view public {
         require(!shouldRevert);
     }
 }

--- a/test/Babylonian.spec.ts
+++ b/test/Babylonian.spec.ts
@@ -25,7 +25,7 @@ describe('Babylonian', () => {
     babylonian = await deployContract(wallet, BabylonianTest, [], overrides)
   })
 
-  describe.only('#sqrt', () => {
+  describe('#sqrt', () => {
     it('works for 0-99', async () => {
       for (let i = 0; i < 100; i++) {
         expect(await babylonian.sqrt(i)).to.eq(Math.floor(Math.sqrt(i)))

--- a/test/Babylonian.spec.ts
+++ b/test/Babylonian.spec.ts
@@ -35,9 +35,9 @@ describe('Babylonian', () => {
     it('product of numbers close to max uint112', async () => {
       const max = BigNumber.from(2).pow(112).sub(1)
       expect(await babylonian.sqrt(max.mul(max))).to.eq(max)
-      const maxMinus1 = BigNumber.from(2).pow(112).sub(2)
+      const maxMinus1 = max.sub(1)
       expect(await babylonian.sqrt(maxMinus1.mul(maxMinus1))).to.eq(maxMinus1)
-      const maxMinus2 = BigNumber.from(2).pow(112).sub(3)
+      const maxMinus2 = max.sub(2)
       expect(await babylonian.sqrt(maxMinus2.mul(maxMinus2))).to.eq(maxMinus2)
 
       expect(await babylonian.sqrt(max.mul(maxMinus1))).to.eq(maxMinus1)

--- a/test/Babylonian.spec.ts
+++ b/test/Babylonian.spec.ts
@@ -25,11 +25,24 @@ describe('Babylonian', () => {
     babylonian = await deployContract(wallet, BabylonianTest, [], overrides)
   })
 
-  describe('#sqrt', () => {
+  describe.only('#sqrt', () => {
     it('works for 0-99', async () => {
       for (let i = 0; i < 100; i++) {
         expect(await babylonian.sqrt(i)).to.eq(Math.floor(Math.sqrt(i)))
       }
+    })
+
+    it('product of numbers close to max uint112', async () => {
+      const max = BigNumber.from(2).pow(112).sub(1)
+      expect(await babylonian.sqrt(max.mul(max))).to.eq(max)
+      const maxMinus1 = BigNumber.from(2).pow(112).sub(2)
+      expect(await babylonian.sqrt(maxMinus1.mul(maxMinus1))).to.eq(maxMinus1)
+      const maxMinus2 = BigNumber.from(2).pow(112).sub(3)
+      expect(await babylonian.sqrt(maxMinus2.mul(maxMinus2))).to.eq(maxMinus2)
+
+      expect(await babylonian.sqrt(max.mul(maxMinus1))).to.eq(maxMinus1)
+      expect(await babylonian.sqrt(max.mul(maxMinus2))).to.eq(maxMinus2)
+      expect(await babylonian.sqrt(maxMinus1.mul(maxMinus2))).to.eq(maxMinus2)
     })
 
     it('max uint256', async () => {

--- a/test/FixedPoint.spec.ts
+++ b/test/FixedPoint.spec.ts
@@ -104,7 +104,7 @@ describe('FixedPoint', () => {
 
     it('fails with 0 denominator', async () => {
       await expect(fixedPoint.fraction(BigNumber.from(1), BigNumber.from(0))).to.be.revertedWith(
-        'FixedPoint: DIV_BY_ZERO'
+        'FixedPoint: DIV_BY_ZERO_FRACTION'
       )
     })
   })
@@ -114,7 +114,7 @@ describe('FixedPoint', () => {
       expect((await fixedPoint.reciprocal([Q112.mul(BigNumber.from(25)).div(100)]))[0]).to.eq(Q112.mul(4))
     })
     it('fails for 0', async () => {
-      await expect(fixedPoint.reciprocal([BigNumber.from(0)])).to.be.revertedWith('FixedPoint: ZERO_RECIPROCAL')
+      await expect(fixedPoint.reciprocal([BigNumber.from(0)])).to.be.revertedWith('FixedPoint: DIV_BY_ZERO_RECIPROCAL')
     })
     it('works for 5', async () => {
       expect((await fixedPoint.reciprocal([Q112.mul(BigNumber.from(5))]))[0]).to.eq(Q112.mul(BigNumber.from(1)).div(5))

--- a/test/FixedPoint.spec.ts
+++ b/test/FixedPoint.spec.ts
@@ -81,7 +81,7 @@ describe('FixedPoint', () => {
       )
     })
     it('max without overflow, largest fixed point', async () => {
-      const maxMultiplier = BigNumber.from('4294967296')
+      const maxMultiplier = BigNumber.from(2).pow(32)
       expect((await fixedPoint.mul([BigNumber.from(2).pow(224).sub(1)], maxMultiplier))[0]).to.eq(
         BigNumber.from('115792089237316195423570985008687907853269984665640564039457584007908834672640')
       )
@@ -121,7 +121,7 @@ describe('FixedPoint', () => {
       ).to.be.revertedWith('FixedPoint: MULTIPLICATION_OVERFLOW')
     })
     it('max without overflow, largest fixed point', async () => {
-      const maxMultiplier = BigNumber.from('4294967296')
+      const maxMultiplier = BigNumber.from(2).pow(32)
       expect(await fixedPoint.muli([BigNumber.from(2).pow(224).sub(1)], maxMultiplier)).to.eq(
         BigNumber.from('22300745198530623141535718272648361505980415')
       )
@@ -174,10 +174,10 @@ describe('FixedPoint', () => {
 
   describe('#reciprocal', () => {
     it('fails for 0', async () => {
-      await expect(fixedPoint.reciprocal([BigNumber.from(0)])).to.be.revertedWith('FixedPoint: DIV_BY_ZERO_RECIPROCAL')
+      await expect(fixedPoint.reciprocal([BigNumber.from(0)])).to.be.revertedWith('FixedPoint: DIV_BY_ZERO_RECIPROCAL_OR_OVERFLOW')
     })
     it('fails for 1', async () => {
-      await expect(fixedPoint.reciprocal([BigNumber.from(1)])).to.be.revertedWith('FixedPoint: RECIPROCAL_OVERFLOW')
+      await expect(fixedPoint.reciprocal([BigNumber.from(1)])).to.be.revertedWith('FixedPoint: DIV_BY_ZERO_RECIPROCAL_OR_OVERFLOW')
     })
     it('works for 0.25', async () => {
       expect((await fixedPoint.reciprocal([Q112.mul(BigNumber.from(25)).div(100)]))[0]).to.eq(Q112.mul(4))

--- a/test/FixedPoint.spec.ts
+++ b/test/FixedPoint.spec.ts
@@ -64,17 +64,6 @@ describe('FixedPoint', () => {
     })
   })
 
-  describe('#div', () => {
-    it('correct division', async () => {
-      expect((await fixedPoint.div([BigNumber.from(3).mul(Q112)], BigNumber.from(2)))[0]).to.eq(
-        BigNumber.from(3).mul(Q112).div(2)
-      )
-    })
-    it('throws for div by zero', async () => {
-      await expect(fixedPoint.div([BigNumber.from(3).mul(Q112)], 0)).to.be.revertedWith('FixedPoint: DIV_BY_ZERO')
-    })
-  })
-
   describe('#mul', () => {
     it('correct multiplication', async () => {
       expect((await fixedPoint.mul([BigNumber.from(3).mul(Q112)], BigNumber.from(2)))[0]).to.eq(
@@ -184,11 +173,14 @@ describe('FixedPoint', () => {
   })
 
   describe('#reciprocal', () => {
-    it('works for 0.25', async () => {
-      expect((await fixedPoint.reciprocal([Q112.mul(BigNumber.from(25)).div(100)]))[0]).to.eq(Q112.mul(4))
-    })
     it('fails for 0', async () => {
       await expect(fixedPoint.reciprocal([BigNumber.from(0)])).to.be.revertedWith('FixedPoint: DIV_BY_ZERO_RECIPROCAL')
+    })
+    it('fails for 1', async () => {
+      await expect(fixedPoint.reciprocal([BigNumber.from(1)])).to.be.revertedWith('FixedPoint: RECIPROCAL_OVERFLOW')
+    })
+    it('works for 0.25', async () => {
+      expect((await fixedPoint.reciprocal([Q112.mul(BigNumber.from(25)).div(100)]))[0]).to.eq(Q112.mul(4))
     })
     it('works for 5', async () => {
       expect((await fixedPoint.reciprocal([Q112.mul(BigNumber.from(5))]))[0]).to.eq(Q112.mul(BigNumber.from(1)).div(5))

--- a/test/FixedPoint.spec.ts
+++ b/test/FixedPoint.spec.ts
@@ -93,6 +93,34 @@ describe('FixedPoint', () => {
     })
   })
 
+  describe('#muli', () => {
+    it('works for 0', async () => {
+      expect(await fixedPoint.muli([BigNumber.from(0).mul(Q112)], BigNumber.from(1))).to.eq(BigNumber.from(0))
+      expect(await fixedPoint.muli([BigNumber.from(1).mul(Q112)], BigNumber.from(0))).to.eq(BigNumber.from(0))
+    })
+
+    it('works for 3*2', async () => {
+      expect(await fixedPoint.muli([BigNumber.from(3).mul(Q112)], BigNumber.from(2))).to.eq(BigNumber.from(6))
+    })
+
+    it('works for 3*-2', async () => {
+      expect(await fixedPoint.muli([BigNumber.from(3).mul(Q112)], BigNumber.from(-2))).to.eq(BigNumber.from(-6))
+    })
+
+    it('works for 3*-2', async () => {
+      expect(await fixedPoint.muli([BigNumber.from(3).mul(Q112)], BigNumber.from(-2))).to.eq(BigNumber.from(-6))
+    })
+
+    it('overflow', async () => {
+      await expect(fixedPoint.muli([BigNumber.from(1).mul(Q112)], BigNumber.from(2).pow(144))).to.be.revertedWith(
+        'FixedPoint: MULTIPLICATION_OVERFLOW'
+      )
+      await expect(
+        fixedPoint.muli([BigNumber.from(1).mul(Q112)], BigNumber.from(2).pow(144).mul(-1))
+      ).to.be.revertedWith('FixedPoint: MULTIPLICATION_OVERFLOW')
+    })
+  })
+
   describe('#fraction', () => {
     it('correct computation less than 1', async () => {
       expect((await fixedPoint.fraction(4, 100))[0]).to.eq(BigNumber.from(4).mul(Q112).div(100))

--- a/test/FixedPoint.spec.ts
+++ b/test/FixedPoint.spec.ts
@@ -122,8 +122,8 @@ describe('FixedPoint', () => {
   })
 
   describe('#sqrt', () => {
-    it('works for 25', async () => {
-      expect((await fixedPoint.sqrt([BigNumber.from(25).mul(Q112)]))[0]).to.eq(BigNumber.from(5).mul(Q112))
+    it('works with 0', async () => {
+      expect((await fixedPoint.sqrt([BigNumber.from(0)]))[0]).to.eq(BigNumber.from(0))
     })
 
     it('works with numbers less than 1', async () => {
@@ -132,8 +132,22 @@ describe('FixedPoint', () => {
       )
     })
 
-    it('works with 0', async () => {
-      expect((await fixedPoint.sqrt([BigNumber.from(0)]))[0]).to.eq(BigNumber.from(0))
+    it('works for 25', async () => {
+      expect((await fixedPoint.sqrt([BigNumber.from(25).mul(Q112)]))[0]).to.eq(BigNumber.from(5).mul(Q112))
+    })
+
+    it('works for max uint112', async () => {
+      const input = BigNumber.from(2).pow(112).sub(1).mul(Q112)
+      const result = (await fixedPoint.sqrt([input]))[0]
+      const expected = BigNumber.from('374144419156711147060143317175368417003121712037887')
+      expect(result).to.eq(expected.shr(40).shl(40))
+    })
+
+    it('works for max uint224', async () => {
+      const input = BigNumber.from(2).pow(224).sub(1)
+      const result = (await fixedPoint.sqrt([input]))[0]
+      const expected = BigNumber.from('374144419156711147060143317175368453031918731001855')
+      expect(result).to.eq(expected.shr(40).shl(40))
     })
   })
 })

--- a/test/FixedPoint.spec.ts
+++ b/test/FixedPoint.spec.ts
@@ -174,10 +174,14 @@ describe('FixedPoint', () => {
 
   describe('#reciprocal', () => {
     it('fails for 0', async () => {
-      await expect(fixedPoint.reciprocal([BigNumber.from(0)])).to.be.revertedWith('FixedPoint: DIV_BY_ZERO_RECIPROCAL_OR_OVERFLOW')
+      await expect(fixedPoint.reciprocal([BigNumber.from(0)])).to.be.revertedWith(
+        'FixedPoint: DIV_BY_ZERO_RECIPROCAL_OR_OVERFLOW'
+      )
     })
     it('fails for 1', async () => {
-      await expect(fixedPoint.reciprocal([BigNumber.from(1)])).to.be.revertedWith('FixedPoint: DIV_BY_ZERO_RECIPROCAL_OR_OVERFLOW')
+      await expect(fixedPoint.reciprocal([BigNumber.from(1)])).to.be.revertedWith(
+        'FixedPoint: DIV_BY_ZERO_RECIPROCAL_OR_OVERFLOW'
+      )
     })
     it('works for 0.25', async () => {
       expect((await fixedPoint.reciprocal([Q112.mul(BigNumber.from(25)).div(100)]))[0]).to.eq(Q112.mul(4))

--- a/test/FixedPoint.spec.ts
+++ b/test/FixedPoint.spec.ts
@@ -91,6 +91,22 @@ describe('FixedPoint', () => {
         BigNumber.from(2).pow(224)
       )
     })
+    it('max without overflow, largest fixed point', async () => {
+      const maxMultiplier = BigNumber.from('4294967296')
+      expect((await fixedPoint.mul([BigNumber.from(2).pow(224).sub(1)], maxMultiplier))[0]).to.eq(
+        BigNumber.from('115792089237316195423570985008687907853269984665640564039457584007908834672640')
+      )
+      await expect(fixedPoint.mul([BigNumber.from(2).pow(224).sub(1)], maxMultiplier.add(1))).to.be.revertedWith(
+        'FixedPoint: MULTIPLICATION_OVERFLOW'
+      )
+    })
+    it('max without overflow, smallest fixed point', async () => {
+      const maxUint = BigNumber.from(2).pow(256).sub(1)
+      expect((await fixedPoint.mul([BigNumber.from(1)], maxUint))[0]).to.eq(maxUint)
+      await expect(fixedPoint.mul([BigNumber.from(2)], maxUint)).to.be.revertedWith(
+        'FixedPoint: MULTIPLICATION_OVERFLOW'
+      )
+    })
   })
 
   describe('#muli', () => {
@@ -107,10 +123,6 @@ describe('FixedPoint', () => {
       expect(await fixedPoint.muli([BigNumber.from(3).mul(Q112)], BigNumber.from(-2))).to.eq(BigNumber.from(-6))
     })
 
-    it('works for 3*-2', async () => {
-      expect(await fixedPoint.muli([BigNumber.from(3).mul(Q112)], BigNumber.from(-2))).to.eq(BigNumber.from(-6))
-    })
-
     it('overflow', async () => {
       await expect(fixedPoint.muli([BigNumber.from(1).mul(Q112)], BigNumber.from(2).pow(144))).to.be.revertedWith(
         'FixedPoint: MULTIPLICATION_OVERFLOW'
@@ -118,6 +130,40 @@ describe('FixedPoint', () => {
       await expect(
         fixedPoint.muli([BigNumber.from(1).mul(Q112)], BigNumber.from(2).pow(144).mul(-1))
       ).to.be.revertedWith('FixedPoint: MULTIPLICATION_OVERFLOW')
+    })
+    it('max without overflow, largest fixed point', async () => {
+      const maxMultiplier = BigNumber.from('4294967296')
+      expect(await fixedPoint.muli([BigNumber.from(2).pow(224).sub(1)], maxMultiplier)).to.eq(
+        BigNumber.from('22300745198530623141535718272648361505980415')
+      )
+      await expect(fixedPoint.muli([BigNumber.from(2).pow(224).sub(1)], maxMultiplier.add(1))).to.be.revertedWith(
+        'FixedPoint: MULTIPLICATION_OVERFLOW'
+      )
+      // negative version
+      expect(await fixedPoint.muli([BigNumber.from(2).pow(224).sub(1)], maxMultiplier.mul(-1))).to.eq(
+        BigNumber.from('22300745198530623141535718272648361505980415').mul(-1)
+      )
+      await expect(
+        fixedPoint.muli([BigNumber.from(2).pow(224).sub(1)], maxMultiplier.add(1).mul(-1))
+      ).to.be.revertedWith('FixedPoint: MULTIPLICATION_OVERFLOW')
+    })
+
+    it('max without overflow, smallest fixed point', async () => {
+      const maxInt = BigNumber.from(2).pow(255).sub(1)
+      expect(await fixedPoint.muli([BigNumber.from(2)], maxInt)).to.eq(
+        BigNumber.from('22300745198530623141535718272648361505980415')
+      )
+      await expect(fixedPoint.muli([BigNumber.from(3)], maxInt)).to.be.revertedWith(
+        'FixedPoint: MULTIPLICATION_OVERFLOW'
+      )
+      // negative version
+      const minInt = BigNumber.from(2).pow(255).mul(-1)
+      expect(await fixedPoint.muli([BigNumber.from(1)], minInt)).to.eq(
+        BigNumber.from('11150372599265311570767859136324180752990208').mul(-1)
+      )
+      await expect(fixedPoint.muli([BigNumber.from(2)], minInt)).to.be.revertedWith(
+        'FixedPoint: MULTIPLICATION_OVERFLOW'
+      )
     })
   })
 


### PR DESCRIPTION
# changelog

## `FixedPoint.sol`

- added explanatory comments about lossiness/reversion
- replaced `uint256` with `uint`
- constrained `Q112`/`Q224` to their smallest possible representation
- remove unnecessary cast in `mul`
- removed `div`
- added `muli`
- added overflow failure case for `reciprocal`
- made `sqrt` less lossy

## other
- added boundary tests for `Babylonian.sqrt`
- added boundary tests for `mul`
- added tests for `muli`