### PR TITLE
Enhancements

### DIFF
--- a/.github/workflows/fuzz-testing.yml
+++ b/.github/workflows/fuzz-testing.yml
@@ -51,3 +51,7 @@ jobs:
       - name: BitMathEchidnaTest
         run: |
           echidna-test . --contract BitMathEchidnaTest --config echidna.config.yml
+
+      - name: FullMathEchidnaTest
+        run: |
+          echidna-test . --contract FullMathEchidnaTest --config echidna.config.yml

--- a/contracts/libraries/FixedPoint.sol
+++ b/contracts/libraries/FixedPoint.sol
@@ -19,9 +19,9 @@ library FixedPoint {
         uint256 _x;
     }
 
-    uint8 private constant RESOLUTION = 112;
-    uint256 private constant Q112 = 0x10000000000000000000000000000;
-    uint256 private constant Q224 = 0x100000000000000000000000000000000000000000000000000000000;
+    uint8 public constant RESOLUTION = 112;
+    uint256 public constant Q112 = 0x10000000000000000000000000000; // 2**112
+    uint256 private constant Q224 = 0x100000000000000000000000000000000000000000000000000000000; // 2**224
     uint256 private constant LOWER_MASK = 0xffffffffffffffffffffffffffff; // decimal of UQ*x112 (lower 112 bits)
 
     // encode a uint112 as a UQ112x112
@@ -44,12 +44,9 @@ library FixedPoint {
         return uint144(self._x >> RESOLUTION);
     }
 
-    // multiply a UQ112x112 by a uint, returning a UQ144x112
-    // reverts on overflow
-    function mul(uq112x112 memory self, uint256 y) internal pure returns (uq144x112 memory) {
-        uint256 z = 0;
-        require(y == 0 || (z = self._x * y) / y == self._x, 'FixedPoint::mul: overflow');
-        return uq144x112(z);
+    // multiply a UQ112x112 by a uint32, returning a UQ144x112
+    function mul(uq112x112 memory self, uint32 y) internal pure returns (uq144x112 memory) {
+        return uq144x112(uint256(self._x) * y);
     }
 
     // multiply a UQ112x112 by an int and decode, returning an int

--- a/contracts/libraries/FixedPoint.sol
+++ b/contracts/libraries/FixedPoint.sol
@@ -107,20 +107,14 @@ library FixedPoint {
     }
 
     // returns a UQ112x112 which represents the ratio of the numerator to the denominator
-    // lossy if either numerator or denominator is greater than 112 bits
+    // can be lossy
     function fraction(uint256 numerator, uint256 denominator) internal pure returns (uq112x112 memory) {
         require(denominator > 0, 'FixedPoint::fraction: division by zero');
         if (numerator == 0) return FixedPoint.uq112x112(0);
 
-        if (numerator <= uint144(-1)) {
-            uint256 result = (numerator << RESOLUTION) / denominator;
-            require(result <= uint224(-1), 'FixedPoint::fraction: overflow');
-            return uq112x112(uint224(result));
-        } else {
-            uint256 result = FullMath.mulDiv(numerator, Q112, denominator);
-            require(result <= uint224(-1), 'FixedPoint::fraction: overflow');
-            return uq112x112(uint224(result));
-        }
+        uint256 result = FullMath.mulDiv(numerator, Q112, denominator);
+        require(result <= uint224(-1), 'FixedPoint::fraction: overflow');
+        return uq112x112(uint224(result));
     }
 
     // take the reciprocal of a UQ112x112

--- a/contracts/libraries/FullMath.sol
+++ b/contracts/libraries/FullMath.sol
@@ -38,10 +38,14 @@ library FullMath {
         uint256 d
     ) internal pure returns (uint256) {
         (uint256 l, uint256 h) = fullMul(x, y);
+
         uint256 mm = mulmod(x, y, d);
         if (mm > l) h -= 1;
         l -= mm;
-        require(h < d, 'FullMath::mulDiv: overflow');
+
+        if (h == 0) return l / d;
+
+        require(h < d, 'FullMath: FULLDIV_OVERFLOW');
         return fullDiv(l, h, d);
     }
 }

--- a/contracts/libraries/FullMath.sol
+++ b/contracts/libraries/FullMath.sol
@@ -4,7 +4,7 @@ pragma solidity >=0.4.0;
 // taken from https://medium.com/coinmonks/math-in-solidity-part-3-percents-and-proportions-4db014e080b1
 // license is CC-BY-4.0
 library FullMath {
-    function fullMul(uint256 x, uint256 y) private pure returns (uint256 l, uint256 h) {
+    function fullMul(uint256 x, uint256 y) internal pure returns (uint256 l, uint256 h) {
         uint256 mm = mulmod(x, y, uint256(-1));
         l = x * y;
         h = mm - l;

--- a/contracts/test/FixedPointTest.sol
+++ b/contracts/test/FixedPointTest.sol
@@ -22,7 +22,7 @@ contract FixedPointTest {
         return FixedPoint.decode144(self);
     }
 
-    function mul(FixedPoint.uq112x112 calldata self, uint256 y) external pure returns (FixedPoint.uq144x112 memory) {
+    function mul(FixedPoint.uq112x112 calldata self, uint32 y) external pure returns (FixedPoint.uq144x112 memory) {
         return FixedPoint.mul(self, y);
     }
 

--- a/contracts/test/FixedPointTest.sol
+++ b/contracts/test/FixedPointTest.sol
@@ -22,7 +22,7 @@ contract FixedPointTest {
         return FixedPoint.decode144(self);
     }
 
-    function mul(FixedPoint.uq112x112 calldata self, uint32 y) external pure returns (FixedPoint.uq144x112 memory) {
+    function mul(FixedPoint.uq112x112 calldata self, uint256 y) external pure returns (FixedPoint.uq144x112 memory) {
         return FixedPoint.mul(self, y);
     }
 

--- a/contracts/test/FullMathEchidnaTest.sol
+++ b/contracts/test/FullMathEchidnaTest.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity >=0.4.0;
+
+import '../libraries/FullMath.sol';
+
+contract FullMathEchidnaTest {
+    function checkH(uint256 x, uint256 y) public pure {
+        // if the mul doesn't overflow in 256-bit space, h should be 0
+        if (x == 0 || ((x * y) / x == y)) {
+            (, uint256 h) = FullMath.fullMul(x, y);
+            assert(h == 0);
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/lib",
-  "version": "4.0.0-alpha",
+  "version": "4.0.1-alpha",
   "description": "📖 Solidity libraries that are shared across Uniswap contracts",
   "files": [
     "contracts",

--- a/test/FixedPoint.spec.ts
+++ b/test/FixedPoint.spec.ts
@@ -65,34 +65,20 @@ describe('FixedPoint', () => {
   })
 
   describe('#mul', () => {
+    it('works for 0', async () => {
+      expect((await fixedPoint.mul([0], 1))[0]).to.eq(0)
+      expect((await fixedPoint.mul([1], 0))[0]).to.eq(0)
+    })
+
     it('correct multiplication', async () => {
       expect((await fixedPoint.mul([BigNumber.from(3).mul(Q112)], BigNumber.from(2)))[0]).to.eq(
         BigNumber.from(3).mul(2).mul(Q112)
       )
     })
-    it('overflow', async () => {
-      await expect(fixedPoint.mul([BigNumber.from(1).mul(Q112)], BigNumber.from(2).pow(144))).to.be.revertedWith(
-        'FixedPoint::mul: overflow'
-      )
-    })
     it('max of q112x112', async () => {
-      expect((await fixedPoint.mul([BigNumber.from(2).pow(112)], BigNumber.from(2).pow(112)))[0]).to.eq(
-        BigNumber.from(2).pow(224)
+      expect((await fixedPoint.mul([BigNumber.from(2).pow(112)], BigNumber.from(2).pow(32).sub(1)))[0]).to.eq(
+        BigNumber.from(2).pow(112).mul(BigNumber.from(2).pow(32).sub(1))
       )
-    })
-    it('max without overflow, largest fixed point', async () => {
-      const maxMultiplier = BigNumber.from(2).pow(32)
-      expect((await fixedPoint.mul([BigNumber.from(2).pow(224).sub(1)], maxMultiplier))[0]).to.eq(
-        BigNumber.from('115792089237316195423570985008687907853269984665640564039457584007908834672640')
-      )
-      await expect(fixedPoint.mul([BigNumber.from(2).pow(224).sub(1)], maxMultiplier.add(1))).to.be.revertedWith(
-        'FixedPoint::mul: overflow'
-      )
-    })
-    it('max without overflow, smallest fixed point', async () => {
-      const maxUint = BigNumber.from(2).pow(256).sub(1)
-      expect((await fixedPoint.mul([BigNumber.from(1)], maxUint))[0]).to.eq(maxUint)
-      await expect(fixedPoint.mul([BigNumber.from(2)], maxUint)).to.be.revertedWith('FixedPoint::mul: overflow')
     })
   })
 
@@ -304,7 +290,7 @@ describe('FixedPoint', () => {
       // long division but makes fewer iterations
       expect(
         await fixedPoint.getGasCostOfDivuq([BigNumber.from(10).pow(10).mul(Q112)], [BigNumber.from(25).mul(Q112)])
-      ).to.eq(1480)
+      ).to.eq(1502)
     })
 
     it('gas cost of long division with all iterations', async () => {
@@ -314,7 +300,7 @@ describe('FixedPoint', () => {
           [BigNumber.from(10).pow(10).mul(Q112)],
           [BigNumber.from(3).mul(BigNumber.from(10).pow(10)).mul(Q112)]
         )
-      ).to.eq(1480)
+      ).to.eq(1502)
     })
   })
 
@@ -356,15 +342,15 @@ describe('FixedPoint', () => {
       expect(await fixedPoint.getGasCostOfFraction(BigNumber.from(0), BigNumber.from(569))).to.eq(210)
     })
     it('gas cost of smaller numbers', async () => {
-      expect(await fixedPoint.getGasCostOfFraction(BigNumber.from(239), BigNumber.from(569))).to.eq(314)
+      expect(await fixedPoint.getGasCostOfFraction(BigNumber.from(239), BigNumber.from(569))).to.eq(588)
     })
     it('gas cost of number greater than Q112 numbers', async () => {
-      expect(await fixedPoint.getGasCostOfFraction(Q112.mul(2359), Q112.mul(2360))).to.eq(314)
+      expect(await fixedPoint.getGasCostOfFraction(Q112.mul(2359), Q112.mul(2360))).to.eq(588)
     })
     it('gas cost of number greater than Q112 numbers', async () => {
       expect(
         await fixedPoint.getGasCostOfFraction(Q112.mul(BigNumber.from(2).pow(32).mul(2359)), Q112.mul(2360))
-      ).to.eq(974)
+      ).to.eq(960)
     })
   })
 


### PR DESCRIPTION
- optimize `mulDiv`
- make `RESOLUTION`/`Q112` public
- make `mul` safe by default
- always use the newly optimized `mulDiv` in `fraction`